### PR TITLE
refactor: Remove FontSizes from Headline apperacne drop down

### DIFF
--- a/src/EventListener/DataContainer/StyleOptionsListener.php
+++ b/src/EventListener/DataContainer/StyleOptionsListener.php
@@ -34,7 +34,6 @@ final class StyleOptionsListener
         return [
             $this->translator->trans('style_options.display', [], 'style_options') => $this->getTranslatedOptions(Typography\Display::class),
             $this->translator->trans('style_options.heading', [], 'style_options') => $this->getTranslatedOptions(Typography\Heading::class),
-            $this->translator->trans('style_options.size', [], 'style_options') => $this->getTranslatedOptions(Typography\FontSize::class),
         ];
     }
 


### PR DESCRIPTION
I propose to remove the FontSize options from the drop down of the Headline appearance. It makes the drop down for the headline to cluttered and my question is if we should realy give Headlines only size modifying options or if that leaves room for errors for editors.

Before:
<img width="403" height="450" alt="image" src="https://github.com/user-attachments/assets/1f81dbb9-a691-44d6-b0cc-128e6f220cc7" />


NOW:
<img width="830" height="317" alt="image" src="https://github.com/user-attachments/assets/6b6e14de-8ac7-4910-b4a3-a2a77dda9d9a" />
