### PR TITLE
migration: map text size options to design system typography

### DIFF
--- a/src/Styles/Option/Typography/FontSize.php
+++ b/src/Styles/Option/Typography/FontSize.php
@@ -9,13 +9,13 @@ use Symfony\Component\Translation\TranslatableMessage;
 
 enum FontSize: string implements TranslatableLabelInterface
 {
-    case x_small = 'text-xs';
-    case small = 'text-sm';
-    case medium = 'text-base';
-    case large = 'md:text-lg';
-    case x_large = 'text-lg md:text-xl';
-    case xx_large = 'text-xl md:text-2xl';
-    case xxx_large = 'text-2xl md:text-3xl';
+    case x_small = 'fixed-body5';
+    case small = 'fixed-body4';
+    case medium = 'fixed-body3';
+    case large = 'fixed-body2';
+    case x_large = 'fixed-body1';
+    case xx_large = 'responsive-headline2';
+    case xxx_large = 'responsive-headline1';
 
     public function label(): TranslatableMessage
     {


### PR DESCRIPTION
We should not have 2 sizing philosopies in our system, rn the sizing options in the backend map to taiwlind classes, we should use the sizes provided by the design system.

<img width="390" height="203" alt="image" src="https://github.com/user-attachments/assets/5a718a9c-f3db-453c-b425-d3c2f2e405a0" />


Issue here is that this could break existing designs like R3 